### PR TITLE
Notes

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
+++ b/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go
@@ -468,6 +468,8 @@ func (m *asgCache) isNodeGroupAvailable(group *autoscaling.Group) (bool, error) 
 	response, err := m.awsService.DescribeScalingActivities(input)
 	observeAWSRequest("DescribeScalingActivities", err, start)
 	if err != nil {
+		klog.Warningf("Couldn't describe scaling activities")
+		klog.Error(err)
 		return true, err // If we can't describe the scaling activities we assume the node group is available
 	}
 

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -371,6 +371,7 @@ func (csr *ClusterStateRegistry) IsNodeGroupHealthy(nodeGroupName string) bool {
 	if !found {
 		// No nodes but target == 0 or just scaling up.
 		if acceptable.CurrentTarget == 0 || (acceptable.MinNodes == 0 && acceptable.CurrentTarget > 0) {
+			klog.Warning("No nodes but target == 0 or just scaling up.")
 			return true
 		}
 		klog.Warningf("Failed to find readiness information for %v", nodeGroupName)

--- a/cluster-autoscaler/clusterstate/clusterstate.go
+++ b/cluster-autoscaler/clusterstate/clusterstate.go
@@ -371,6 +371,7 @@ func (csr *ClusterStateRegistry) IsNodeGroupHealthy(nodeGroupName string) bool {
 	if !found {
 		// No nodes but target == 0 or just scaling up.
 		if acceptable.CurrentTarget == 0 || (acceptable.MinNodes == 0 && acceptable.CurrentTarget > 0) {
+			// TODO: we should only return true if node group is not DEGRADED
 			klog.Warning("No nodes but target == 0 or just scaling up.")
 			return true
 		}

--- a/cluster-autoscaler/clusterstate/clusterstate_test.go
+++ b/cluster-autoscaler/clusterstate/clusterstate_test.go
@@ -420,6 +420,7 @@ func TestExpiredScaleUp(t *testing.T) {
 			{NodeGroup: provider.GetNodeGroup("ng1"), Time: now, Reason: metrics.Timeout},
 		},
 	})
+	// TODO: test CA tries next priority node group
 }
 
 func TestRegisterScaleDown(t *testing.T) {

--- a/cluster-autoscaler/core/scale_up.go
+++ b/cluster-autoscaler/core/scale_up.go
@@ -392,9 +392,11 @@ func ScaleUp(context *context.AutoscalingContext, processors *ca_processors.Auto
 		if nodeGroup.Exist() && !clusterStateRegistry.IsNodeGroupSafeToScaleUp(nodeGroup, now) {
 			// Hack that depends on internals of IsNodeGroupSafeToScaleUp.
 			if !clusterStateRegistry.IsNodeGroupHealthy(nodeGroup.Id()) {
+				// TODO: we would expect to see this when ASG is DEGRADED, but it seems like we don't
 				klog.Warningf("Node group %s is not ready for scaleup - unhealthy", nodeGroup.Id())
 				skippedNodeGroups[nodeGroup.Id()] = notReadyReason
 			} else {
+				// This, we do see
 				klog.Warningf("Node group %s is not ready for scaleup - backoff", nodeGroup.Id())
 				skippedNodeGroups[nodeGroup.Id()] = backoffReason
 			}

--- a/cluster-autoscaler/core/scale_up_test.go
+++ b/cluster-autoscaler/core/scale_up_test.go
@@ -704,6 +704,8 @@ func TestScaleUpUnhealthy(t *testing.T) {
 	assert.NoError(t, err)
 	// Node group is unhealthy.
 	assert.False(t, scaleUpStatus.WasSuccessful())
+
+	// TODO: can test priorities in a similar way?
 }
 
 func TestScaleUpNoHelp(t *testing.T) {

--- a/cluster-autoscaler/expander/priority/priority_test.go
+++ b/cluster-autoscaler/expander/priority/priority_test.go
@@ -167,3 +167,5 @@ func TestPriorityExpanderCorrecltySkipsBadChangeConfig(t *testing.T) {
 	assert.EqualValues(t, configWarnConfigMapEmpty, event)
 	assert.Empty(t, ret)
 }
+
+// TODO: test priority expander falls back to lower priorities when node groups are degraded


### PR DESCRIPTION
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


Expected behavior: the CA should attempt to scale up node groups in priority order until new nodes are successfully registered to the cluster.

Actual behavior: node groups that currently have 0 instances, and which are in a DEGRADED state (because there are no instances available in that AZ), are considered healthy by the CA, which continuously increments their desiredCount instead of moving to the next possible node group.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
